### PR TITLE
WatchOS xcscheme: Commit changes that Xcode wants to make.

### DIFF
--- a/YapDatabase.xcodeproj/xcshareddata/xcschemes/TestModuleMap-watchOS (Glance).xcscheme
+++ b/YapDatabase.xcodeproj/xcshareddata/xcschemes/TestModuleMap-watchOS (Glance).xcscheme
@@ -41,8 +41,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -52,8 +50,8 @@
             ReferencedContainer = "container:YapDatabase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -78,17 +76,6 @@
             ReferencedContainer = "container:YapDatabase.xcodeproj">
          </BuildableReference>
       </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DC6266C81D80D3E000557968"
-            BuildableName = "TestModuleMap-watchOS.app"
-            BlueprintName = "TestModuleMap-watchOS"
-            ReferencedContainer = "container:YapDatabase.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/YapDatabase.xcodeproj/xcshareddata/xcschemes/TestModuleMap-watchOS (Notification).xcscheme
+++ b/YapDatabase.xcodeproj/xcshareddata/xcschemes/TestModuleMap-watchOS (Notification).xcscheme
@@ -41,8 +41,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -52,8 +50,8 @@
             ReferencedContainer = "container:YapDatabase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -78,17 +76,6 @@
             ReferencedContainer = "container:YapDatabase.xcodeproj">
          </BuildableReference>
       </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DC6266C81D80D3E000557968"
-            BuildableName = "TestModuleMap-watchOS.app"
-            BlueprintName = "TestModuleMap-watchOS"
-            ReferencedContainer = "container:YapDatabase.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/YapDatabase.xcodeproj/xcshareddata/xcschemes/TestModuleMap-watchOS.xcscheme
+++ b/YapDatabase.xcodeproj/xcshareddata/xcschemes/TestModuleMap-watchOS.xcscheme
@@ -41,8 +41,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -52,8 +50,8 @@
             ReferencedContainer = "container:YapDatabase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,17 +75,6 @@
             ReferencedContainer = "container:YapDatabase.xcodeproj">
          </BuildableReference>
       </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DC6266C81D80D3E000557968"
-            BuildableName = "TestModuleMap-watchOS.app"
-            BlueprintName = "TestModuleMap-watchOS"
-            ReferencedContainer = "container:YapDatabase.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Xcode always auto-makes these changes whenever we hit build (for Photoleap), so
they constantly show up in our git diffs as a submodule change.
We'd like these changes committed to the repo so that this annoyance goes away.

For context, it seems that Xcode makes changes to these files depending on whether or not the target device (i.e. that you are building for) has a paired Apple Watch or not (this includes simulator builds as well as real devices).  In other words Xcode always changes them to a particular state if you have a paired Watch, and to another state if you don't.  
At the moment the YapDB repo has the `.xcscheme`s setup in the state where the target device **does** have a paired Apple Watch.  Seems fair to assume that the majority of us will be running on devices **without** a paired Watch, so would make more sense to have `.xcscheme`s committed in this "state".