### PR TITLE
YapDatabase: adapt for Xcode 26.5.

### DIFF
--- a/YapDatabase/Extensions/ActionManager/Utilities/YapReachability.m
+++ b/YapDatabase/Extensions/ActionManager/Utilities/YapReachability.m
@@ -46,7 +46,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>

--- a/YapDatabase/Extensions/View/YapDatabaseViewConnection.m
+++ b/YapDatabase/Extensions/View/YapDatabaseViewConnection.m
@@ -99,7 +99,7 @@
 		[self _flushStatements];
 	}
 	
-	if (flags & YapDatabaseConnectionFlushMemoryFlags_Extension_State)
+	if (flags & (NSUInteger)YapDatabaseConnectionFlushMemoryFlags_Extension_State)
 	{
 		state = nil;
 	}

--- a/YapDatabase/YapDatabaseConnection.m
+++ b/YapDatabase/YapDatabaseConnection.m
@@ -2586,7 +2586,7 @@ static int connectionBusyHandler(void *ptr, int count)
 		if (!changesets) // we could not retrieve changeset due to a change from another process.
 		{
 			NSUInteger flags = YapDatabaseConnectionFlushMemoryFlags_Caches |
-			                   YapDatabaseConnectionFlushMemoryFlags_Extension_State;
+			                   (NSUInteger)YapDatabaseConnectionFlushMemoryFlags_Extension_State;
 			
 			[self _flushMemoryWithFlags:flags];
 			snapshot = dbSnapshot;
@@ -2918,7 +2918,7 @@ static int connectionBusyHandler(void *ptr, int count)
 		if (!changesets) // we could not retrieve changeset due to a change from another process.
 		{
 			NSUInteger flags = YapDatabaseConnectionFlushMemoryFlags_Caches |
-			                   YapDatabaseConnectionFlushMemoryFlags_Extension_State;
+			                   (NSUInteger)YapDatabaseConnectionFlushMemoryFlags_Extension_State;
 			
 			[self _flushMemoryWithFlags:flags];
 			snapshot = dbSnapshot;
@@ -4188,7 +4188,7 @@ static int connectionBusyHandler(void *ptr, int count)
 	if (changeset_modifiedExternally)
 	{
 		NSUInteger flags = YapDatabaseConnectionFlushMemoryFlags_Caches |
-		                   YapDatabaseConnectionFlushMemoryFlags_Extension_State;
+		                   (NSUInteger)YapDatabaseConnectionFlushMemoryFlags_Extension_State;
 		
 		[self _flushMemoryWithFlags:flags];
 	}
@@ -4542,7 +4542,7 @@ static int connectionBusyHandler(void *ptr, int count)
 		snapshot = changesetSnapshot;
 		
 		NSUInteger flags = YapDatabaseConnectionFlushMemoryFlags_Caches |
-		                   YapDatabaseConnectionFlushMemoryFlags_Extension_State;
+		                   (NSUInteger)YapDatabaseConnectionFlushMemoryFlags_Extension_State;
 		
 		[self _flushMemoryWithFlags:flags];
 		[self processChangeset:changeset];


### PR DESCRIPTION
## Summary
- Drop unused `#import <netinet6/in6.h>` from YapReachability.m (Xcode 26.5 flags it as a private module-internal include).
- Cast `YapDatabaseConnectionFlushMemoryFlags_Extension_State` to `NSUInteger` at the bitwise sites in YapDatabaseConnection.m and YapDatabaseViewConnection.m to silence `-Wenum-enum-conversion`, now an error under Xcode 26.5.

Tested via Enlight's Xcode 26.5 trial branch.